### PR TITLE
Elliptic-curve cryptography

### DIFF
--- a/src/mbedtls/asn1write.cpp
+++ b/src/mbedtls/asn1write.cpp
@@ -370,7 +370,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
             return( NULL );
 
         cur->oid.len = oid_len;
-        cur->oid.p = mbedtls_calloc( 1, oid_len );
+        cur->oid.p = (unsigned char*)mbedtls_calloc( 1, oid_len );
         if( cur->oid.p == NULL )
         {
             mbedtls_free( cur );
@@ -380,7 +380,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
         memcpy( cur->oid.p, oid, oid_len );
 
         cur->val.len = val_len;
-        cur->val.p = mbedtls_calloc( 1, val_len );
+        cur->val.p = (unsigned char*)mbedtls_calloc( 1, val_len );
         if( cur->val.p == NULL )
         {
             mbedtls_free( cur->oid.p );
@@ -403,7 +403,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
             return( NULL );
 
         mbedtls_free( cur->val.p );
-        cur->val.p = p;
+        cur->val.p = (unsigned char*)p;
         cur->val.len = val_len;
     }
 

--- a/src/mbedtls/config.h
+++ b/src/mbedtls/config.h
@@ -963,7 +963,7 @@
  *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
  *      MBEDTLS_TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
  */
-//#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 
 /**
  * \def MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
@@ -1872,7 +1872,7 @@
  *          library/x509write_crt.c
  *          library/x509write_csr.c
  */
-//#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_ASN1_WRITE_C
 
 /**
  * \def MBEDTLS_BASE64_C
@@ -2184,7 +2184,7 @@
  *
  * Requires: MBEDTLS_ECP_C
  */
-//#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECDH_C
 
 /**
  * \def MBEDTLS_ECDSA_C
@@ -2199,7 +2199,7 @@
  *
  * Requires: MBEDTLS_ECP_C, MBEDTLS_ASN1_WRITE_C, MBEDTLS_ASN1_PARSE_C
  */
-//#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECDSA_C
 
 /**
  * \def MBEDTLS_ECJPAKE_C
@@ -2232,7 +2232,7 @@
  *
  * Requires: MBEDTLS_BIGNUM_C and at least one MBEDTLS_ECP_DP_XXX_ENABLED
  */
-//#define MBEDTLS_ECP_C
+#define MBEDTLS_ECP_C
 
 /**
  * \def MBEDTLS_ENTROPY_C

--- a/src/mbedtls/debug.cpp
+++ b/src/mbedtls/debug.cpp
@@ -301,11 +301,11 @@ static void debug_print_pk( const mbedtls_ssl_context *ssl, int level,
         name[sizeof( name ) - 1] = '\0';
 
         if( items[i].type == MBEDTLS_PK_DEBUG_MPI )
-            mbedtls_debug_print_mpi( ssl, level, file, line, name, items[i].value );
+            mbedtls_debug_print_mpi( ssl, level, file, line, name, (const mbedtls_mpi*)items[i].value );
         else
 #if defined(MBEDTLS_ECP_C)
         if( items[i].type == MBEDTLS_PK_DEBUG_ECP )
-            mbedtls_debug_print_ecp( ssl, level, file, line, name, items[i].value );
+            mbedtls_debug_print_ecp( ssl, level, file, line, name, (const mbedtls_ecp_point*)items[i].value );
         else
 #endif
             debug_send_line( ssl, level, file, line,

--- a/src/mbedtls/ecp.cpp
+++ b/src/mbedtls/ecp.cpp
@@ -1145,7 +1145,7 @@ static int ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
         return( mbedtls_internal_ecp_normalize_jac_many( grp, T, T_size ) );
 #endif
 
-    if( ( c = mbedtls_calloc( T_size, sizeof( mbedtls_mpi ) ) ) == NULL )
+    if( ( c = (mbedtls_mpi*)mbedtls_calloc( T_size, sizeof( mbedtls_mpi ) ) ) == NULL )
         return( MBEDTLS_ERR_ECP_ALLOC_FAILED );
 
     for( i = 0; i < T_size; i++ )
@@ -2045,7 +2045,7 @@ static int ecp_mul_comb( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 #endif
     /* Allocate table if we didn't have any */
     {
-        T = mbedtls_calloc( T_size, sizeof( mbedtls_ecp_point ) );
+        T = (mbedtls_ecp_point*)mbedtls_calloc( T_size, sizeof( mbedtls_ecp_point ) );
         if( T == NULL )
         {
             ret = MBEDTLS_ERR_ECP_ALLOC_FAILED;

--- a/src/mbedtls/pk_wrap.cpp
+++ b/src/mbedtls/pk_wrap.cpp
@@ -243,7 +243,7 @@ static int eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     mbedtls_ecdsa_init( &ecdsa );
 
-    if( ( ret = mbedtls_ecdsa_from_keypair( &ecdsa, ctx ) ) == 0 )
+    if( ( ret = mbedtls_ecdsa_from_keypair( &ecdsa, (const mbedtls_ecp_keypair*)ctx ) ) == 0 )
         ret = ecdsa_verify_wrap( &ecdsa, md_alg, hash, hash_len, sig, sig_len );
 
     mbedtls_ecdsa_free( &ecdsa );
@@ -261,7 +261,7 @@ static int eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     mbedtls_ecdsa_init( &ecdsa );
 
-    if( ( ret = mbedtls_ecdsa_from_keypair( &ecdsa, ctx ) ) == 0 )
+    if( ( ret = mbedtls_ecdsa_from_keypair( &ecdsa, (const mbedtls_ecp_keypair*)ctx ) ) == 0 )
         ret = ecdsa_sign_wrap( &ecdsa, md_alg, hash, hash_len, sig, sig_len,
                                f_rng, p_rng );
 
@@ -387,7 +387,7 @@ static void *eckey_alloc_wrap( void )
     void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_ecp_keypair ) );
 
     if( ctx != NULL )
-        mbedtls_ecp_keypair_init( ctx );
+        mbedtls_ecp_keypair_init( (mbedtls_ecp_keypair*)ctx );
 
     return( ctx );
 }


### PR DESCRIPTION
This patch enables Elliptic-curve cryptography (ECC).

This is done in two steps:
1. The right settings are enabled in the mbedtls which is
   included in this package.
2. Compiler errors in the included mbedtls code are fixed
   to get the code compiling.